### PR TITLE
First cut at a Heroku configurator Concourse resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ configurables:
   WOW_I_HATE_YAML: 'It is an escaping purgatory'
   LOW_GRADE_PANIC: 'Fnord.'
 ```
+
+This resource requires the HEROKU_API_KEY system
+environment variable to contain a valid Heroku API key.

--- a/bin/out
+++ b/bin/out
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 
 from lib.heroku import configure_heroku_from_yaml
-import os
 
-
-print(os.getcwd())
 configure_heroku_from_yaml("heroku_configs.yml")
 

--- a/lib/heroku.py
+++ b/lib/heroku.py
@@ -5,7 +5,7 @@ import logging
 
 
 def set_config(heroku_app: str, var: str, value: str):
-    logging.debug(f"Setting Heroku app {heroku_app=} config variable {var=}")
+    print(f"Setting Heroku app {heroku_app=} config variable {var=}")
     heroku_conn = heroku3.from_key(getenv("HEROKU_API_KEY"))
     current_app = heroku_conn.apps()[heroku_app]
     config = current_app.config()

--- a/lib/heroku.py
+++ b/lib/heroku.py
@@ -1,15 +1,6 @@
 import heroku3  # type: ignore
 from os import getenv
 from yaml import safe_load
-import logging
-
-
-def set_config(heroku_app: str, var: str, value: str):
-    print(f"Setting Heroku app {heroku_app=} config variable {var=}")
-    heroku_conn = heroku3.from_key(getenv("HEROKU_API_KEY"))
-    current_app = heroku_conn.apps()[heroku_app]
-    config = current_app.config()
-    config[var] = value
 
 
 def configure_heroku_from_yaml(yaml_file: str):
@@ -18,7 +9,8 @@ def configure_heroku_from_yaml(yaml_file: str):
 
     # Heroku application to configure
     heroku_app = configurator["heroku_application"]
+    heroku_conn = heroku3.from_key(getenv("HEROKU_API_KEY"))
 
     configurables = configurator["configurables"]
-    for configurable_name in configurables.keys():
-        set_config(heroku_app, configurable_name, configurables[configurable_name])
+    print(f"Updating {heroku_app=} with config vars {configurables.keys()=}")
+    heroku_conn.update_appconfig(heroku_app, configurables)


### PR DESCRIPTION
# What are the relevant tickets?

https://github.com/mitodl/ol-infrastructure/issues/620


# Description (What does it do?)

Lets a concourse pipeline configure Heroku configuration variables from a YAML file input.


# How can this be tested?

Created a test input YAML. Verified variables were created in Heroku application.
